### PR TITLE
ci: add branch name and PR title validation workflows

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,0 +1,48 @@
+name: Branch Name Check
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
+
+jobs:
+  validate-branch-name:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check bot user
+        id: bot-check
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          echo "PR author: $PR_AUTHOR"
+          if [[ "$PR_AUTHOR" == *"[bot]"* ]]; then
+            echo "✓ Bot user detected - skipping validation"
+            echo "is_bot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_bot=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate branch name
+        if: steps.bot-check.outputs.is_bot == 'false'
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          echo "Checking branch name: $BRANCH"
+
+          # 보호 브랜치는 검사하지 않음
+          if [[ "$BRANCH" =~ ^(main|master|develop|staging)$ ]]; then
+            echo "✓ Protected branch - skipping validation"
+            exit 0
+          fi
+
+          # 패턴: type/description 또는 type/segment1/segment2/... (depth 제한 없음)
+          # 허용: 소문자(a-z), 숫자(0-9), 하이픈(-), 점(.), 언더바(_)
+          PATTERN="^[a-z]+/[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*$"
+
+          if [[ ! "$BRANCH" =~ $PATTERN ]]; then
+            echo "❌ Invalid branch name: $BRANCH"
+            exit 1
+          fi
+
+          echo "✓ Branch name is valid"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,58 @@
+name: "Lint PR"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check bot user
+        id: bot-check
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [[ "$PR_AUTHOR" == *"[bot]"* ]]; then
+            echo "✓ Bot user detected - skipping validation"
+            echo "is_bot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_bot=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: amannn/action-semantic-pull-request@v6
+        if: steps.bot-check.outputs.is_bot == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Scope is optional (allows both `type: title` and `type(scope): title`)
+          requireScope: false
+
+          # Disallow uppercase scopes
+          disallowScopes: |
+            [A-Z]+
+
+          # Work in progress PR support
+          wip: true
+
+          # Skip validation for PRs with these labels
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+
+          # Ensure the subject doesn't start with an uppercase character
+          subjectPattern: ^[a-z].*$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            starts with a lowercase character.


### PR DESCRIPTION
## Summary
- PR 생성 시 브랜치명 컨벤션을 검사하는 GitHub Actions 워크플로우 추가
- PR 타이틀이 Conventional Commits 형식을 따르는지 검사하는 워크플로우 추가
- 봇 사용자(dependabot 등)는 검사를 건너뛰도록 처리

## Test plan
- [ ] 잘못된 브랜치명으로 PR 생성 시 `branch-name-check` 워크플로우 실패 확인
- [ ] 올바른 브랜치명으로 PR 생성 시 통과 확인
- [ ] Conventional Commits 형식이 아닌 PR 타이틀로 실패 확인
- [ ] 봇 사용자의 PR에서 검사가 스킵되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)