### PR TITLE
fix(auth): protect routes for unauthenticated users and align password validation

### DIFF
--- a/.agents/rules/architecture/auth.md
+++ b/.agents/rules/architecture/auth.md
@@ -51,12 +51,14 @@ import { fetchSignIn } from '@features/auth-signin/api/signinService';
 ```ts
 callbacks: {
   async jwt({ token, user, trigger }) {
-    if (trigger === 'update') token.user = await fetchUser();
-    if (user) token.user = user;
-    return token;
+    if (trigger === 'update') {
+      const updateUser = await fetchUser();
+      return { ...token, ...user, ...updateUser.data };
+    }
+    return { ...token, ...user };
   },
   async session({ session, token }) {
-    session.user = token.user as User;
+    session.user = { ...session.user, ...token };
     return session;
   },
 },

--- a/.agents/rules/architecture/auth.md
+++ b/.agents/rules/architecture/auth.md
@@ -1,10 +1,10 @@
 ---
 paths:
-  - "src/app/auth/**"
-  - "src/app/api/auth/**"
-  - "src/features/auth-*/**"
-  - "src/entities/auth/**"
-  - "src/middleware.ts"
+  - 'src/app/auth/**'
+  - 'src/app/api/auth/**'
+  - 'src/features/auth-*/**'
+  - 'src/entities/auth/**'
+  - 'src/middleware.ts'
 ---
 
 # Auth Guide
@@ -29,10 +29,10 @@ NextAuth 설정은 **`src/app/auth/config.ts`** — app 레이어 멤버.
 
 `src/app/auth/config.ts`는 다음 두 함수를 **슬라이스 내부 경로**로 직접 import한다:
 
-| 함수 | 경로 | 이유 |
-|---|---|---|
-| `fetchUser` | `@entities/auth/api/userServices` | `next/headers`(server-only) 사용 → barrel로 내보내면 클라이언트 번들 오염 |
-| `fetchSignIn` | `@features/auth-signin/api/signinService` | 동일 |
+| 함수          | 경로                                      | 이유                                                                      |
+| ------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
+| `fetchUser`   | `@entities/auth/api/userServices`         | `next/headers`(server-only) 사용 → barrel로 내보내면 클라이언트 번들 오염 |
+| `fetchSignIn` | `@features/auth-signin/api/signinService` | 동일                                                                      |
 
 호출부에는 반드시 다음을 같이 적는다:
 
@@ -105,6 +105,17 @@ export const config = {
 ```
 
 여기 추가/제거는 middleware 한 곳에서만. page.tsx 내부에서 수동 `redirect()` 금지 — 일관성/중복 방지.
+
+미인증 차단은 `config.ts`의 `callbacks.authorized`가 담당한다 — `false`를 반환하면 NextAuth 미들웨어가 `pages.signIn`(`/signin`)으로 리다이렉트한다. 이 콜백이 없으면 미들웨어는 세션만 노출하고 차단하지 않으므로 삭제 금지.
+
+```ts
+callbacks: {
+  authorized({ auth }) {
+    return !!auth?.user;
+  },
+  ...
+}
+```
 
 ---
 

--- a/src/app/(domain)/(auth)/signin/signin.spec.tsx
+++ b/src/app/(domain)/(auth)/signin/signin.spec.tsx
@@ -5,7 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { cookies } from 'next/headers';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import React from 'react';
 
@@ -14,6 +14,7 @@ jest.mock('next/headers', () => ({
 }));
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
 }));
 jest.mock('next-auth/react');
 
@@ -25,6 +26,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe('로그인 테스트', () => {
   const mockPush = jest.fn();
+  let mockSearchParams: URLSearchParams;
 
   beforeEach(() => {
     (cookies as jest.Mock).mockResolvedValue({
@@ -35,6 +37,10 @@ describe('로그인 테스트', () => {
     (useRouter as jest.Mock).mockReturnValue({
       push: mockPush,
     });
+
+    mockPush.mockClear();
+    mockSearchParams = new URLSearchParams();
+    (useSearchParams as jest.Mock).mockReturnValue(mockSearchParams);
 
     // given - 로그인 페이지가 그려짐
     render(<SignIn />, { wrapper });
@@ -54,6 +60,40 @@ describe('로그인 테스트', () => {
       fireEvent.submit(screen.getByTestId('submit-button'));
 
       // then - 회원가입 성공
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/'));
+    });
+
+    test('callbackUrl이 있으면 로그인 성공 후 해당 경로로 이동한다', async () => {
+      (signIn as jest.Mock).mockResolvedValue({ ok: true });
+      mockSearchParams.set('callbackUrl', '/account');
+
+      // when - 로그인 성공
+      fireEvent.change(screen.getByLabelText('Email address'), {
+        target: { value: 'test@email.com' },
+      });
+      fireEvent.change(screen.getByLabelText('Password'), {
+        target: { value: 'Password11!!' },
+      });
+      fireEvent.submit(screen.getByTestId('submit-button'));
+
+      // then - callbackUrl 경로로 복귀
+      await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/account'));
+    });
+
+    test('외부 origin callbackUrl은 무시하고 홈으로 이동한다', async () => {
+      (signIn as jest.Mock).mockResolvedValue({ ok: true });
+      mockSearchParams.set('callbackUrl', 'https://evil.example.com/x');
+
+      // when - 로그인 성공
+      fireEvent.change(screen.getByLabelText('Email address'), {
+        target: { value: 'test@email.com' },
+      });
+      fireEvent.change(screen.getByLabelText('Password'), {
+        target: { value: 'Password11!!' },
+      });
+      fireEvent.submit(screen.getByTestId('submit-button'));
+
+      // then - open redirect 차단
       await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/'));
     });
 

--- a/src/app/(domain)/(auth)/signup/signup.spec.tsx
+++ b/src/app/(domain)/(auth)/signup/signup.spec.tsx
@@ -189,7 +189,21 @@ describe('회원가입 테스트', () => {
       // then - 에러메세지가 표시됨
       const errorMessage = await screen.findByRole('password-error-message');
       expect(errorMessage).toHaveTextContent(
-        'Password must contain at least one uppercase letter, one lowercase letter, and one number'
+        'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character'
+      );
+    });
+
+    test('비밀번호에 특수문자만 누락돼도 에러메세지가 표시된다', async () => {
+      // when - 대문자·소문자·숫자는 충족하고 특수문자만 없음
+      fireEvent.change(screen.getByLabelText('Password'), {
+        target: { value: 'Password123' },
+      });
+      fireEvent.submit(screen.getByTestId('submit-button'));
+
+      // then - 에러메세지가 표시됨
+      const errorMessage = await screen.findByRole('password-error-message');
+      expect(errorMessage).toHaveTextContent(
+        'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character'
       );
     });
 

--- a/src/app/(domain)/(auth)/signup/signup.spec.tsx
+++ b/src/app/(domain)/(auth)/signup/signup.spec.tsx
@@ -193,6 +193,20 @@ describe('회원가입 테스트', () => {
       );
     });
 
+    test('공백은 특수문자로 인정하지 않는다', async () => {
+      // when - 특수문자 대신 끝 공백만 포함
+      fireEvent.change(screen.getByLabelText('Password'), {
+        target: { value: 'Password123 ' },
+      });
+      fireEvent.submit(screen.getByTestId('submit-button'));
+
+      // then - 에러메세지가 표시됨
+      const errorMessage = await screen.findByRole('password-error-message');
+      expect(errorMessage).toHaveTextContent(
+        'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character'
+      );
+    });
+
     test('비밀번호에 특수문자만 누락돼도 에러메세지가 표시된다', async () => {
       // when - 대문자·소문자·숫자는 충족하고 특수문자만 없음
       fireEvent.change(screen.getByLabelText('Password'), {

--- a/src/app/auth/config.ts
+++ b/src/app/auth/config.ts
@@ -49,6 +49,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     }),
   ],
   callbacks: {
+    authorized({ auth }) {
+      return !!auth?.user;
+    },
     async jwt({ token, user, trigger }) {
       if (trigger === 'update') {
         const updateUser = await fetchUser();

--- a/src/entities/auth/ui/AuthForm/PasswordInput.tsx
+++ b/src/entities/auth/ui/AuthForm/PasswordInput.tsx
@@ -51,7 +51,7 @@ export default function PasswordInput() {
               value:
                 /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,}$/,
               message:
-                'Password must contain at least one uppercase letter, one lowercase letter, and one number',
+                'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character',
             },
           })}
         />

--- a/src/entities/auth/ui/AuthForm/PasswordInput.tsx
+++ b/src/entities/auth/ui/AuthForm/PasswordInput.tsx
@@ -49,7 +49,7 @@ export default function PasswordInput() {
             },
             pattern: {
               value:
-                /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$ %^&*-]).{8,}$/,
+                /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$/,
               message:
                 'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character',
             },

--- a/src/features/auth-signin/model/useSignInForm.ts
+++ b/src/features/auth-signin/model/useSignInForm.ts
@@ -1,15 +1,33 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { SignInReq } from '../api/types';
 
+// 절대 URL·프로토콜 상대(//) callbackUrl은 open redirect가 되므로 same-origin 경로만 복귀 허용
+const resolveCallbackUrl = (callbackUrl: string | null) => {
+  if (!callbackUrl) {
+    return '/';
+  }
+
+  try {
+    const url = new URL(callbackUrl, window.location.origin);
+    if (url.origin !== window.location.origin) {
+      return '/';
+    }
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return '/';
+  }
+};
+
 export function useSignInForm() {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const methods = useForm<SignInReq>();
 
@@ -22,7 +40,7 @@ export function useSignInForm() {
     });
 
     if (res?.ok) {
-      router.push('/');
+      router.push(resolveCallbackUrl(searchParams.get('callbackUrl')));
     } else {
       alert('Failed to sign in');
       setIsLoading(false);


### PR DESCRIPTION
## Summary

런타임 검증 중 발견된 인증 관련 기존 버그 2건 수정 + codex 리뷰 지적 2건 반영.

### 1. 미인증 보호 라우트 리다이렉트 (버그)
- `config.ts`에 `callbacks.authorized`가 없어 미들웨어가 세션만 노출하고 차단하지 않았음 — matcher의 `/account`, `/post/create`, `/post/:id/update`가 미인증 상태로 렌더됨
- `authorized` 콜백 추가 → 미인증 시 `/signin?callbackUrl=...`로 307
- (codex 지적) 로그인 성공 시 `callbackUrl` 무시하고 항상 `/`로 가던 것도 수정 — same-origin 경로만 복귀 허용, 외부 origin은 `/` 폴백 (open redirect 차단)
- `auth.md` §6에 메커니즘 문서화, §3 예시 코드 실제 구현과 동기화

### 2. 비밀번호 검증 메시지/규칙 정합 (버그)
- regex는 특수문자를 요구하는데 에러 메시지는 대문자·소문자·숫자만 안내 → 메시지에 특수문자 조건 반영
- (codex 지적) 특수문자 클래스에 공백이 포함돼 `"Password123 "`이 통과하던 잠재 버그 제거

## Test plan

- [x] `npm run tsc` / `npm run lint`(0 errors) / `npm test`(7 suites·48 tests) / `npm run build` 통과
- [x] 신규 테스트 4건: 특수문자 누락 메시지, 공백 비인정, callbackUrl 복귀, 외부 origin 차단
- [x] 런타임 검증 (mock 서버 + dev + 브라우저 자동화):
  - 미인증 보호 라우트 3곳 → 307 `/signin?callbackUrl=...`, 공개 라우트 200 유지
  - 로그아웃 즉시 미들웨어 리다이렉트 동작
  - `/signin?callbackUrl=/account`에서 로그인 → `/account` 복귀
  - 새 에러 메시지 화면 렌더 확인
- [x] codex 적대적 리뷰 4건 중 3건 반영, 1건(스펙 파일의 when/then 주석)은 기존 파일 전체 스타일과의 일관성 유지 사유로 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)